### PR TITLE
Tweaks to Curve and LinePlot visibility to allow Scala to work w/out runtime errors. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*~
+#*
+target
+.target
+.lib
+.history
+.cache
+.project
+.classpath
+project/boot
+lib_managed
+src_managed
+.ensime

--- a/src/main/java/com/googlecode/charts4j/Curve.java
+++ b/src/main/java/com/googlecode/charts4j/Curve.java
@@ -27,16 +27,16 @@ package com.googlecode.charts4j;
 
 /**
  * Curve super type.
- *
+ * 
  * @author Julien Chastang (julien.c.chastang at gmail dot com)
  */
-interface Curve extends Plot {
+public interface Curve extends Plot {
 
     /**
      * Define a fill area color below this plot. Order is important! If you have
      * multiple plots, you may have your fill areas obscure each other. You may
      * have to experiment to get the result you want.
-     *
+     * 
      * @param color
      *            The color of the fill area that will appear below this
      *            particular plot. cannot be null.

--- a/src/main/java/com/googlecode/charts4j/LinePlot.java
+++ b/src/main/java/com/googlecode/charts4j/LinePlot.java
@@ -25,18 +25,17 @@
 
 package com.googlecode.charts4j;
 
-
 /**
  * For line plots including radar charts.
- *
+ * 
  * @author Julien Chastang (julien.c.chastang at gmail dot com)
  * @see Plots
  */
-interface LinePlot extends Curve{
+public interface LinePlot extends Curve {
 
     /**
      * Set the line style.
-     *
+     * 
      * @param lineStyle
      *            The line style to set. Cannot be null.
      */
@@ -44,7 +43,7 @@ interface LinePlot extends Curve{
 
     /**
      * Set the priority.
-     *
+     * 
      * @param priority
      *            for this plot. Cannot be null.
      */


### PR DESCRIPTION
This change is just adding public to these 2 interfaces. Scala apparently has a constraint that any of the interfaces implemented have to be publically visible to be used from a different package. To be honest, it actually makes sense (at least to me ;^) 

The https://github.com/langley/hackqd master branch has lines commented out and and marked with this comment. 
/\* Line below has runtime error... perhaps from https://issues.scala-lang.org/browse/SI-1806  */
the hack/tweak_ifaces-C4J-1.4-SNAPSHOT branch shows the same code and illustrates these changes being used successfully. 
